### PR TITLE
Fixed issue with multiple popovers

### DIFF
--- a/public/resources/javascript/setup/popover.js
+++ b/public/resources/javascript/setup/popover.js
@@ -15,7 +15,8 @@ module.exports = function () {
         viewport: { selector: 'body', padding: 20 }
     })
     
-    // Initialise Bootstrap tooltips
-    //http://getbootstrap.com/javascript/#tooltips
-    $('[data-toggle="tooltip"]').tooltip()
+    // destroy all exsisting popovers
+    $('[data-toggle="popover"]').bind('click', function(){
+        $('.popover').popover('destroy');
+    });
 }


### PR DESCRIPTION
Remove unneeded tooltip initialisation and added script to remove existing popovers to display only one at the time. 
---

**Testing**

On the main page click on images and make sure that only one tooltip open at the time.

---

**Deployment steps**

Merge branch `issue4` into `master`

Compile assets: `./bin/node_modules/gulp`
